### PR TITLE
rename columns before writing out file

### DIFF
--- a/R/group_data.R
+++ b/R/group_data.R
@@ -10,8 +10,8 @@ group_by_ndays <- function(df, ndays, period_name) {
 #'           expects sessions, users, view_id, view_name, date columns
 #' @return data frame with total users and sessions for previous year, month, and day for each application
 group_day_month_year <- function(df) {
-  year_df <- group_by_ndays(df, ndays = 365, period_name = "365_days")
-  month_df <- group_by_ndays(df, ndays = 30, period_name = "30_days")
-  week_df <- group_by_ndays(df, ndays = 7, period_name = "7_days")
+  year_df <- group_by_ndays(df, ndays = 365, period_name = "365 days")
+  month_df <- group_by_ndays(df, ndays = 30, period_name = "30 days")
+  week_df <- group_by_ndays(df, ndays = 7, period_name = "7 days")
   return_df <- bind_rows(year_df, month_df, week_df)
 }

--- a/R/pull_GA_data.R
+++ b/R/pull_GA_data.R
@@ -157,11 +157,8 @@ regionality_metric <- compute_regionality_metric(state_traffic_percentages)
 write_df_to_parquet(regionality_metric,
                     sink = 'out/regionality/regionality.parquet')
 
-state_week_vs_year <- compute_week_vs_year(state_traffic_all)
-state_week_vs_year <- state_week_vs_year %>% 
-  rename("365_days" = "365 days") %>%
-  rename("30_days" = "30 days") %>%
-  rename("7_days" = "7 days")
+state_week_vs_year <- compute_week_vs_year(state_traffic_all) %>%
+  rename("365_days" = "365 days", "30_days" = "30 days", "7_days" = "7 days")
 write_df_to_parquet(state_week_vs_year,
                     sink = 'out/state_week_vs_year/state_week_vs_year.parquet')
 

--- a/R/pull_GA_data.R
+++ b/R/pull_GA_data.R
@@ -158,6 +158,10 @@ write_df_to_parquet(regionality_metric,
                     sink = 'out/regionality/regionality.parquet')
 
 state_week_vs_year <- compute_week_vs_year(state_traffic_all)
+state_week_vs_year <- state_week_vs_year %>% 
+  rename("365_days" = "365 days") %>%
+  rename("30_days" = "30 days") %>%
+  rename("7_days" = "7 days")
 write_df_to_parquet(state_week_vs_year,
                     sink = 'out/state_week_vs_year/state_week_vs_year.parquet')
 


### PR DESCRIPTION
i originally changed the group_data.R file thinking I could just make this change to have underscores in the names, but that will not group properly since those periods don't match the other periods. therefore I am undoing that and suggesting we rename the columns ahead of exporting the file in the parquet format. this should help get the data in the file as well athena should handle the column names better than those with spaces which it rejects