### PR TITLE
modified state week/year metric, added 'all NWISweb' view

### DIFF
--- a/R/functions.R
+++ b/R/functions.R
@@ -70,36 +70,6 @@ backfill_app_data <- function(df, min_date) {
   return(backfilled)
 }
 
-
-#' Function to combine Water Science School and water.usgs.gov
-#' Could be generalized further to combine two groups in a grouped
-#' data.frame, but not worthwhile for now
-#' 
-#' @param df data frame expecting certain columns from Google Analytics
-#' @param view_name_pattern string that will be matched against the 
-#' view_name columns.  All rows that match it will be combined by year/month
-#'
-add_drupal_natweb_sum <- function(df, view_name_pattern) {
-  df_groups_to_sum <- df %>% filter(grepl(x = view_name, pattern = view_name_pattern)) 
-  new_group <- df_groups_to_sum %>% 
-    mutate(pageViews = sessions * pageviewsPerSession,
-           newSessions = sessions * (percentNewSessions*0.01),
-           totalSessionDuration = sessions * avgSessionDuration) %>% 
-    group_by(year, month) %>% 
-    summarize(sessions = sum(sessions),
-              pageViews = sum(pageViews),
-              newSessions = sum(newSessions),
-              totalSessionDuration = sum(totalSessionDuration)) %>% 
-    mutate(avgSessionDuration = totalSessionDuration/sessions,
-           pageviewsPerSession = pageViews/sessions,
-           percentNewSessions = newSessions/sessions*100,
-           view_name = view_name_pattern,
-           view_id = view_name_pattern) %>% 
-      select(-newSessions, -pageViews, -totalSessionDuration)
-  df_plus_new_group <- bind_rows(df, new_group)
-  return(df_plus_new_group)
-}
-
 #' filter out leap days in a data frame with a 'date' column
 remove_leap_days <- function(df) {
   df %>% mutate(month = month(date),

--- a/R/functions.R
+++ b/R/functions.R
@@ -120,28 +120,18 @@ compare_sessions_to_last_year <- function(df, last_n_days, period_name) {
 }
 
 #splice together new legacy NWISweb view w/old data to create a continuous timeseries
-#could probably be generalized at a later time
 #' @param splice_date date at which timeseries should switch to newer data source
-splice_legacy_nwisweb <- function(df, splice_date, 
+splice_two_views <- function(df, splice_date, 
                                   view_to_fill_in,
-                                  view_to_fill_with) {
-  #fill in newer timeseries with older data before a certain date
-  # df_filtered <- df %>% 
-  #   filter(view_name %in% c("NWISWeb (Legacy Desktop)", "NWISWeb (NextGen + Legacy Desktop)")) %>% 
-  #   pivot_longer(cols = c("sessions", "users"), names_to = "metric") %>% 
-  #   pivot_wider(id_cols = c("view_id", "view_name", "date", "metric"),
-  #               names_from = c("view_name", "view_id"),
-  #               values_from = c("value")) %>% 
-  #   mutate(`NWISWeb (Legacy Desktop)_221302252` = coalesce(na_if(`NWISWeb (Legacy Desktop)_221302252`, 0),
-  #                                                      `NWISWeb (NextGen + Legacy Desktop)_49785472`)) %>% 
-  #   pivot_longer()
-  view_df_fill_in <- df %>% filter(view_name == view_to_fill_in, date >= splice_date)
-  view_df_fill_with <- df %>% filter(view_name == view_to_fill_with, date < splice_date)
+                                  view_to_fill_with,
+                              date_col) {
+  view_df_fill_in <- df %>% filter(view_name == view_to_fill_in, {{date_col}} >= splice_date)
+  view_df_fill_with <- df %>% filter(view_name == view_to_fill_with, {{date_col}} < splice_date)
   view_filled_in <- bind_rows(view_df_fill_with, view_df_fill_in) %>% 
     mutate(view_name = view_to_fill_in, view_id = tail(view_id, n = 1))
   df_out <- df %>% filter(view_name != view_to_fill_in) %>% 
     bind_rows(view_filled_in)
-  stopifnot(nrow(df_out) != nrow(df))
+  stopifnot(nrow(df_out) == nrow(df))
   return(df_out)
 }
   

--- a/R/functions.R
+++ b/R/functions.R
@@ -119,4 +119,29 @@ compare_sessions_to_last_year <- function(df, last_n_days, period_name) {
   return(both_years)
 }
 
- 
+#splice together new legacy NWISweb view w/old data to create a continuous timeseries
+#could probably be generalized at a later time
+#' @param splice_date date at which timeseries should switch to newer data source
+splice_legacy_nwisweb <- function(df, splice_date, 
+                                  view_to_fill_in,
+                                  view_to_fill_with) {
+  #fill in newer timeseries with older data before a certain date
+  # df_filtered <- df %>% 
+  #   filter(view_name %in% c("NWISWeb (Legacy Desktop)", "NWISWeb (NextGen + Legacy Desktop)")) %>% 
+  #   pivot_longer(cols = c("sessions", "users"), names_to = "metric") %>% 
+  #   pivot_wider(id_cols = c("view_id", "view_name", "date", "metric"),
+  #               names_from = c("view_name", "view_id"),
+  #               values_from = c("value")) %>% 
+  #   mutate(`NWISWeb (Legacy Desktop)_221302252` = coalesce(na_if(`NWISWeb (Legacy Desktop)_221302252`, 0),
+  #                                                      `NWISWeb (NextGen + Legacy Desktop)_49785472`)) %>% 
+  #   pivot_longer()
+  view_df_fill_in <- df %>% filter(view_name == view_to_fill_in, date >= splice_date)
+  view_df_fill_with <- df %>% filter(view_name == view_to_fill_with, date < splice_date)
+  view_filled_in <- bind_rows(view_df_fill_with, view_df_fill_in) %>% 
+    mutate(view_name = view_to_fill_in, view_id = tail(view_id, n = 1))
+  df_out <- df %>% filter(view_name != view_to_fill_in) %>% 
+    bind_rows(view_filled_in)
+  stopifnot(nrow(df_out) != nrow(df))
+  return(df_out)
+}
+  

--- a/R/group_data.R
+++ b/R/group_data.R
@@ -15,3 +15,51 @@ group_day_month_year <- function(df) {
   week_df <- group_by_ndays(df, ndays = 7, period_name = "7 days")
   return_df <- bind_rows(year_df, month_df, week_df)
 }
+
+merge_app_groups <- function(df_groups_to_sum, new_name) {
+  UseMethod("merge_app_groups", df_groups_to_sum)
+}
+merge_app_groups.long_term <- function(df_groups_to_sum, new_name) {
+  new_group <- df_groups_to_sum %>% 
+    mutate(pageViews = sessions * pageviewsPerSession,
+           newSessions = sessions * (percentNewSessions*0.01),
+           totalSessionDuration = sessions * avgSessionDuration) %>% 
+    group_by(year, month) %>% 
+    summarize(sessions = sum(sessions),
+              pageViews = sum(pageViews),
+              newSessions = sum(newSessions),
+              totalSessionDuration = sum(totalSessionDuration)) %>% 
+    mutate(avgSessionDuration = totalSessionDuration/sessions,
+           pageviewsPerSession = pageViews/sessions,
+           percentNewSessions = newSessions/sessions*100,
+           view_name = new_name,
+           view_id = new_name) %>% 
+    select(-newSessions, -pageViews, -totalSessionDuration)
+  return(new_group)
+}
+merge_app_groups.state <- function(df_groups_to_sum, new_name) {
+  df_groups_to_sum %>% group_by(region, country, period) %>% 
+    summarize(sessions = sum(sessions)) %>% 
+    mutate(view_name = new_name,
+           view_id = new_name)
+}
+merge_app_groups.three_year_traffic <- function(df_groups_to_sum, new_name) {
+  df_groups_to_sum %>% group_by(date) %>% 
+    summarize(sessions = sum(sessions)) %>% 
+    mutate(view_name = new_name,
+           view_id = new_name)
+}
+
+#' Combine the contents of two views
+#' 
+#' @param df data frame expecting certain columns from Google Analytics
+#' @param view_name_pattern string that will be matched against the 
+#' view_name columns.  All rows that match it will be combined by year/month
+#'
+add_sum_of_views <- function(df, view_name_pattern, method, new_name = view_name_pattern) {
+  df_groups_to_sum <- df %>% filter(grepl(x = view_name, pattern = view_name_pattern))
+  class(df_groups_to_sum) <- c(method, class(df_groups_to_sum))
+  new_group <- merge_app_groups(df_groups_to_sum, new_name)
+  df_plus_new_group <- bind_rows(df, new_group)
+  return(df_plus_new_group)
+}

--- a/R/pull_GA_data.R
+++ b/R/pull_GA_data.R
@@ -131,7 +131,9 @@ write_df_to_parquet(regionality_metric,
                     sink = 'out/regionality/regionality.parquet')
 
 state_week_vs_year <- compute_week_vs_year(state_traffic_all) %>%
-  rename("365_days" = "365 days", "30_days" = "30 days", "7_days" = "7 days")
+  rename("365_days" = "365 days", "30_days" = "30 days", "7_days" = "7 days") %>% 
+  mutate(weekly_average = `365_days`/52.14,
+         week_percent_from_average = (`7_days` - weekly_average)/weekly_average * 100)
 write_df_to_parquet(state_week_vs_year,
                     sink = 'out/state_week_vs_year/state_week_vs_year.parquet')
 

--- a/R/pull_GA_data.R
+++ b/R/pull_GA_data.R
@@ -46,7 +46,12 @@ traffic_data <- get_multiple_view_ga_df(view_df = ga_table,
   add_sum_of_views(view_name_pattern = "Water Science School", method = "three_year_traffic") %>% 
   add_sum_of_views(view_name_pattern = "water.usgs.gov", method = "three_year_traffic") %>% 
   add_sum_of_views(view_name_pattern = nwisweb_all_regex,
-                   new_name = nwisweb_all, method = "three_year_traffic") 
+                   new_name = nwisweb_all, method = "three_year_traffic") %>% 
+  splice_two_views(splice_date = "2020-06-16", 
+                   view_to_fill_in = "NWISWeb (Legacy Desktop)",
+                   view_to_fill_with = "NWISWeb (NextGen + Legacy Desktop)",
+                   date_col = date)
+
 traffic_data_out <- traffic_data %>% mutate(year = year_to_jan_1st(lubridate::year(date)),
                                             fiscal_year = year_to_jan_1st(dataRetrieval::calcWaterYear(date)))
 
@@ -86,6 +91,10 @@ traffic_data_long_term <- get_multiple_view_ga_df(view_df = ga_table,
   add_sum_of_views(view_name_pattern = nwisweb_all_regex,
                    new_name = nwisweb_all, method = "long_term") %>% 
   mutate(first_of_month = as.Date(paste(year, month, "01", sep = "-"))) %>% 
+  splice_two_views(splice_date = "2020-06-16", 
+                   view_to_fill_in = "NWISWeb (Legacy Desktop)",
+                   view_to_fill_with = "NWISWeb (NextGen + Legacy Desktop)",
+                   date_col = first_of_month) %>% 
   #Drop pre-launch data to eliminate massive percent increases in traffic
   filter(sessions > 0,
          first_of_month > '2016-06-01' | view_name != 'NWISWeb (Mapper)',

--- a/gaTable.yaml
+++ b/gaTable.yaml
@@ -439,7 +439,7 @@
   analyticsContact: 'Jim Kreft'
   analyticsContactEmail: 'jkreft@usgs.gov'
 
-- longName: NWISWeb (Legacy)
+- longName: NWISWeb (NextGen + Legacy Desktop)
   shortName: NWISWebDesktop
   accountName: USGS Water Data for the Nation
   viewID: '49785472'
@@ -447,6 +447,28 @@
   webPropertyId: UA-25350863-1
   internalWebPropertyId: '49291662'
   viewName: ''
+  timezone: 'America/Denver'
+  websiteUrl: http://waterdata.usgs.gov
+  botFilteringEnabled: ''
+  description: >-
+    This site is the public web interface to the USGS National Water Information System optimized
+    for desktop users (NWISWebDesktop). These
+    pages provide access to water-resources data collected at approximately 1.5 million sites
+    in all 50 States, the District of Columbia, Puerto Rico, the Virgin Islands, Guam, American
+    Samoa and the Commonwealth of the Northern Mariana Islands.
+  projectContact: 'Jim Kreft'
+  projectContactEmail: 'jkreft@usgs.gov'
+  analyticsContact: 'Jim Kreft'
+  analyticsContactEmail: 'jkreft@usgs.gov'
+
+- longName: NWISWeb (Legacy Desktop)
+  shortName: NWISWebLegacyDesktop
+  accountName: USGS Water Data for the Nation
+  viewID: '221302252'
+  accountId: '25350863'
+  webPropertyId: UA-25350863-1
+  internalWebPropertyId: '49291662'
+  viewName: 'legacy content'
   timezone: 'America/Denver'
   websiteUrl: http://waterdata.usgs.gov
   botFilteringEnabled: ''


### PR DESCRIPTION
 - Made the week/year metric and percent difference from the average to make it more interpretable
 - Added an 'all NWISweb' metric by summing NWIS Mobile, the current desktop (new and old), and NWIS mapper.  A fair bit of new code to do this.  Requested by Nate.  Adding together sessions from different products isn't ideal if we are trying to consider them as one 'product', but the only alternative would be comparing client IDs distinguish users of both.  That doesn't translate to sessions though without going all the way to client ids + pageviews and recreating the sessions ourselves.  Something to consider down the road, but too big a lift for right now