### PR TITLE
adding recent vizlab pages

### DIFF
--- a/gaTable.yaml
+++ b/gaTable.yaml
@@ -1054,9 +1054,9 @@
 - longName: "VizLab: Fire-Hydrology"
   shortName: VizLabFireHydro
   accountName: How wildfires threaten U.S. water supplies
-  viewID: ""
-  accountId: "250646489"
-  webPropertyId: "250646489"
+  viewID: "241450737"
+  accountId: "78530187"
+  webPropertyId: "UA-78530187-19"
   internalWebPropertyId: ""
   viewName: "All Web Site Data"
   timezone: America/Chicago

--- a/gaTable.yaml
+++ b/gaTable.yaml
@@ -1051,3 +1051,20 @@
   analyticsContact: "David Watkins"
   analyticsContactEmail: "wwatkins@usgs.gov"
   
+- longName: "VizLab: Fire-Hydrology"
+  shortName: VizLabFireHydro
+  accountName: How wildfires threaten U.S. water supplies
+  viewID: ""
+  accountId: "250646489"
+  webPropertyId: "250646489"
+  internalWebPropertyId: ""
+  viewName: "All Web Site Data"
+  timezone: America/Chicago
+  websiteUrl: https://labs.waterdata.usgs.gov/visualizations/fire-hydro/index.html#/
+  botFilteringEnabled: "TRUE"
+  description: "An interactive website about wildfire impacts to U.S. water supplies"
+  projectContact: "Colleen Nell"
+  projectContactEmail: "cnell@usgs.gov"
+  analyticsContact: "David Watkins"
+  analyticsContactEmail: "wwatkins@usgs.gov"
+  

--- a/gaTable.yaml
+++ b/gaTable.yaml
@@ -1068,3 +1068,20 @@
   analyticsContact: "David Watkins"
   analyticsContactEmail: "wwatkins@usgs.gov"
   
+- longName: "VizLab: Snow to flow"
+  shortName: VizLabSnowToFlow
+  accountName: Snowmelt and water supply visualization
+  viewID: "241431169"
+  accountId: "78530187"
+  webPropertyId: "UA-78530187-18"
+  internalWebPropertyId: ""
+  viewName: "All Web Site Data"
+  timezone: America/Chicago
+  websiteUrl: https://labs.waterdata.usgs.gov/visualizations/snow-to-flow/index.html#/
+  botFilteringEnabled: "TRUE"
+  description: "An interactive website about snowmelt in the western U.S."
+  projectContact: "Colleen Nell"
+  projectContactEmail: "cnell@usgs.gov"
+  analyticsContact: "David Watkins"
+  analyticsContactEmail: "wwatkins@usgs.gov"
+  

--- a/gaTable.yaml
+++ b/gaTable.yaml
@@ -1033,3 +1033,21 @@
   projectContactEmail: "tburley@usgs.gov"
   analyticsContact: "Ramona Neafie"
   analyticsContactEmail: "rjneafie@usgs.gov"
+
+- longName: "VizLab: Delaware Basin Story"
+  shortName: VizLabDRBstory
+  accountName: Water Science in the Delaware River Basin visualization
+  viewID: "222356746"
+  accountId: "78530187"
+  webPropertyId: "UA-78530187-15"
+  internalWebPropertyId: ""
+  viewName: "All Web Site Data"
+  timezone: America/Chicago
+  websiteUrl: https://labs.waterdata.usgs.gov/visualizations/delaware-basin-story/index.html#/
+  botFilteringEnabled: "TRUE"
+  description: "A scrollytelling website about water management in the Delaware River Basin"
+  projectContact: "Colleen Nell"
+  projectContactEmail: "cnell@usgs.gov"
+  analyticsContact: "David Watkins"
+  analyticsContactEmail: "wwatkins@usgs.gov"
+  


### PR DESCRIPTION
Adding the DRB story and fire-hydro pages to `gaTable.yaml`. I think the DRB story is done correctly, however, the google analytics tag for the fire page is different (not UA) and doesn't offer the same information as far as I can tell. I'm not sure how to fill out the `viewID` for this page. 

Do you have any guidance on this? Perhaps I set up the analytics tag incorrectly, in which case I could use feedback for the next 2 pages that are about to come out.

