### PR TITLE
add google auth vars

### DIFF
--- a/R/functions.R
+++ b/R/functions.R
@@ -136,7 +136,6 @@ splice_two_views <- function(df, splice_date,
 }
   
 get_nwis_site_page_views <- function(date_range = c('2020-01-01', '2020-02-01')) {
-  gar_auth_service('~/.vizlab/VIZLAB-a48f4107248c.json')
   nwis_web_view <- '49785472'
   
   #filter 

--- a/R/noms_date_range_pull.R
+++ b/R/noms_date_range_pull.R
@@ -9,6 +9,10 @@ yesterday <- Sys.Date()-1
 
 yesterday <- seq(from=yesterday, to=yesterday, by='days')
 
+gar_set_client(json = Sys.getenv('GA_CLIENTID_FILE'), 
+               scopes = "https://www.googleapis.com/auth/analytics.readonly")
+gar_auth_service(json_file = Sys.getenv('GA_AUTH_FILE'))
+
 source('R/functions.R')
 source('R/group_data.R')
 


### PR DESCRIPTION
originally i moved the function to the pull_GA_data.R file but when that was sourced it ran all the pulls for the analytics pipeline I really didn't need. after moving the function to the functions.R file, this PR aims to remove the file-specific auth (borrowed from here https://code.usgs.gov/wwatkins/ad_hoc_analytics/-/blob/master/nwis_web_hit_count_2020/nwis_site_pages.R) and use the system environmental vars instead